### PR TITLE
fix: remove time wrapper

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -7,18 +7,6 @@ import (
 	"time"
 )
 
-// Timer interface to abstract time-based operations for retries.
-type Timer interface {
-	After(time.Duration) <-chan time.Time
-}
-
-// timerImpl implements the Timer interface using time.After.
-type timerImpl struct{}
-
-func (t timerImpl) After(d time.Duration) <-chan time.Time {
-	return time.After(d)
-}
-
 // RetryableFuncWithResponse represents a function that returns an HTTP response or an error.
 type RetryableFuncWithResponse func() (*http.Response, error)
 
@@ -61,7 +49,7 @@ func Retry(retryableFunc RetryableFuncWithResponse, options ...RetryOption) (*ht
 		}
 
 		select {
-		case <-opts.timer.After(backoffDuration):
+		case <-time.After(backoffDuration):
 		case <-opts.context.Done():
 			return nil, opts.context.Err()
 		}

--- a/retry_options.go
+++ b/retry_options.go
@@ -18,7 +18,6 @@ type RetryConfig struct {
 	maxJitter time.Duration
 	onRetry   OnRetryFunc
 	retryIf   RetryIfFunc
-	timer     Timer
 	context   context.Context
 }
 
@@ -33,7 +32,6 @@ func newDefaultRetryConfig() *RetryConfig {
 		maxJitter: 0 * time.Second,                            // no jitter by default
 		onRetry:   func(n uint, err error) {},                 // no-op onRetry by default
 		retryIf:   func(err error) bool { return err != nil }, // retry on any error by default
-		timer:     &timerImpl{},
 		context:   context.Background(),
 	}
 }


### PR DESCRIPTION
No need to use a time wrapper; Keep it simple.

Instead of using the time wrapper customizable by the user just go with the default time package.