### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,3 @@ func main() {
 
 ## License
 This project is licensed under the Apache License. See the [LICENSE](LICENSE) file for details.
-
-## 
-
-Simplification of the Avast [retry-go](https://github.com/avast/retry-go) module


### PR DESCRIPTION
# Update readme

Due to simplifications and implementation details is no longer similar to any other retry go module thus, removing references as it not the same and works differently.