### PR TITLE
feat(backoff strategies): enable backoff strategies and backoff limit

### DIFF
--- a/retry_options.go
+++ b/retry_options.go
@@ -13,12 +13,14 @@ type RetryIfFunc func(error) bool
 
 // RetryConfig contains configuration options for the retry mechanism.
 type RetryConfig struct {
-	retries   uint
-	backoff   time.Duration
-	maxJitter time.Duration
-	onRetry   OnRetryFunc
-	retryIf   RetryIfFunc
-	context   context.Context
+	retries         uint
+	backoff         time.Duration
+	backoffStrategy func(base time.Duration, n uint) time.Duration
+	backoffLimit    time.Duration // maximum backoff time allowed
+	maxJitter       time.Duration
+	onRetry         OnRetryFunc
+	retryIf         RetryIfFunc
+	context         context.Context
 }
 
 // RetryOption is a function type for modifying RetryConfig options.
@@ -27,11 +29,13 @@ type RetryOption func(*RetryConfig)
 // newDefaultRetryConfig creates a default RetryConfig with sensible defaults.
 func newDefaultRetryConfig() *RetryConfig {
 	return &RetryConfig{
-		retries:   3,
-		backoff:   1 * time.Second,
-		maxJitter: 0 * time.Second,                            // no jitter by default
-		onRetry:   func(n uint, err error) {},                 // no-op onRetry by default
-		retryIf:   func(err error) bool { return err != nil }, // retry on any error by default
-		context:   context.Background(),
+		retries:         3,
+		backoff:         1 * time.Second,
+		backoffStrategy: func(base time.Duration, n uint) time.Duration { return base },
+		backoffLimit:    0,                                          // no limit by default
+		maxJitter:       0,                                          // no jitter by default
+		onRetry:         func(n uint, err error) {},                 // no-op onRetry by default
+		retryIf:         func(err error) bool { return err != nil }, // retry on any error by default
+		context:         context.Background(),
 	}
 }

--- a/retry_test.go
+++ b/retry_test.go
@@ -105,4 +105,235 @@ func TestRetryWithNoSuccessStatusOnAnyRequest(t *testing.T) {
 	if elapsedTime < expectedMinimumTime {
 		t.Errorf("Expected minimum time of %v, but got %v", expectedMinimumTime, elapsedTime)
 	}
+
+	// check if the difference between times is not too high (as is a controlled environment the difference should be minimal)
+	if elapsedTime-expectedMinimumTime > time.Second {
+		t.Errorf("Expected minimum time of %v, but got %v", expectedMinimumTime, elapsedTime)
+	}
+}
+
+// TestRetryWithBackoffLimit tests the retry mechanism with a server that always returns a 429 status code and a backoff limit.
+func TestRetryWithBackoffLimit(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	var backoffTime = 2 * time.Second
+	var retryCount uint = 0
+	var expectedRetries uint = 3
+
+	sendRequest := func() (*http.Response, error) {
+		return http.Get(server.URL + "/notfound")
+	}
+
+	startTime := time.Now()
+
+	resp, err := Retry(
+		sendRequest,
+		WithBackoff(backoffTime),
+		WithBackoffLimit(1*time.Second),
+		WithOnRetry(func(n uint, err error) {
+			retryCount = n
+			log.Printf("Retrying request after error: %v", err)
+		}),
+	)
+
+	endTime := time.Now()
+
+	elapsedTime := endTime.Sub(startTime)
+	expectedMinimumTime := 3 * time.Second
+
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+
+	if resp != nil {
+		defer resp.Body.Close()
+		t.Errorf("Expected nil response, got %v", resp.Body)
+	}
+
+	if retryCount != expectedRetries {
+		t.Errorf("Expected 3 retries, but got %d", retryCount)
+	}
+
+	if elapsedTime < expectedMinimumTime {
+		t.Errorf("Expected minimum time of %v, but got %v", expectedMinimumTime, elapsedTime)
+	}
+
+	// check if the difference between times is not too high (as is a controlled environment the difference should be minimal)
+	if elapsedTime-expectedMinimumTime > time.Second {
+		t.Errorf("Expected minimum time of %v, but got %v", expectedMinimumTime, elapsedTime)
+	}
+
+}
+
+// TestRetryWithWithLinearBackoff tests the retry mechanism with a server that always returns a 429 status code.
+func TestRetryWithWithLinearBackoff(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	var backoffTime = 2 * time.Second
+	var retryCount uint = 0
+	var expectedRetries uint = 3
+
+	sendRequest := func() (*http.Response, error) {
+		return http.Get(server.URL + "/notfound")
+	}
+
+	startTime := time.Now()
+
+	resp, err := Retry(
+		sendRequest,
+		WithBackoff(backoffTime),
+		WithLinearBackoff(),
+		WithOnRetry(func(n uint, err error) {
+			retryCount = n
+			log.Printf("Retrying request after error: %v", err)
+		}),
+	)
+
+	endTime := time.Now()
+
+	elapsedTime := endTime.Sub(startTime)
+	expectedMinimumTime := backoffTime + (backoffTime * 2) + (backoffTime * 3)
+
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+
+	if resp != nil {
+		defer resp.Body.Close()
+		t.Errorf("Expected nil response, got %v", resp.Body)
+	}
+
+	if retryCount != expectedRetries {
+		t.Errorf("Expected 3 retries, but got %d", retryCount)
+	}
+
+	if elapsedTime < expectedMinimumTime {
+		t.Errorf("Expected minimum time of %v, but got %v", expectedMinimumTime, elapsedTime)
+	}
+
+	// check if the difference between times is not too high (as is a controlled environment the difference should be minimal)
+	if elapsedTime-expectedMinimumTime > time.Second {
+		t.Errorf("Expected minimum time of %v, but got %v", expectedMinimumTime, elapsedTime)
+	}
+
+}
+
+// TestRetryWithWithExponentialBackoff tests the retry mechanism with a server that always returns a 429 status code.
+func TestRetryWithWithExponentialBackoff(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	var backoffTime = 2 * time.Second
+	var retryCount uint = 0
+	var expectedRetries uint = 3
+
+	sendRequest := func() (*http.Response, error) {
+		return http.Get(server.URL + "/notfound")
+	}
+
+	startTime := time.Now()
+
+	resp, err := Retry(
+		sendRequest,
+		WithBackoff(backoffTime),
+		WithExponentialBackoff(),
+		WithOnRetry(func(n uint, err error) {
+			retryCount = n
+			log.Printf("Retrying request after error: %v", err)
+		}),
+	)
+
+	endTime := time.Now()
+
+	elapsedTime := endTime.Sub(startTime)
+	expectedMinimumTime := (backoffTime * 2) + (backoffTime * 4) + (backoffTime * 8)
+
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+
+	if resp != nil {
+		defer resp.Body.Close()
+		t.Errorf("Expected nil response, got %v", resp.Body)
+	}
+
+	if retryCount != expectedRetries {
+		t.Errorf("Expected 3 retries, but got %d", retryCount)
+	}
+
+	if elapsedTime < expectedMinimumTime {
+		t.Errorf("Expected minimum time of %v, but got %v", expectedMinimumTime, elapsedTime)
+	}
+
+	// check if the difference between times is not too high (as is a controlled environment the difference should be minimal)
+	if elapsedTime-expectedMinimumTime > time.Second {
+		t.Errorf("Expected minimum time of %v, but got %v", expectedMinimumTime, elapsedTime)
+	}
+
+}
+
+// TestRetryWithWithCustomBackoff tests the retry mechanism with a server that always returns a 429 status code.
+func TestRetryWithWithCustomBackoff(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	var backoffTime = 2 * time.Second
+	var retryCount uint = 0
+	var expectedRetries uint = 3
+
+	sendRequest := func() (*http.Response, error) {
+		return http.Get(server.URL + "/notfound")
+	}
+
+	startTime := time.Now()
+
+	resp, err := Retry(
+		sendRequest,
+		WithBackoff(backoffTime),
+		// Dummy custom backoff function that always returns the same time as the backoffTime
+		WithCustomBackoff(func(base time.Duration, n uint) time.Duration {
+			return backoffTime
+		}),
+		WithOnRetry(func(n uint, err error) {
+			retryCount = n
+			log.Printf("Retrying request after error: %v", err)
+		}),
+	)
+
+	endTime := time.Now()
+
+	elapsedTime := endTime.Sub(startTime)
+	expectedMinimumTime := backoffTime * 3
+
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+
+	if resp != nil {
+		defer resp.Body.Close()
+		t.Errorf("Expected nil response, got %v", resp.Body)
+	}
+
+	if retryCount != expectedRetries {
+		t.Errorf("Expected 3 retries, but got %d", retryCount)
+	}
+
+	if elapsedTime < expectedMinimumTime {
+		t.Errorf("Expected minimum time of %v, but got %v", expectedMinimumTime, elapsedTime)
+	}
+
+	// check if the difference between times is not too high (as is a controlled environment the difference should be minimal)
+	if elapsedTime-expectedMinimumTime > time.Second {
+		t.Errorf("Expected minimum time of %v, but got %v", expectedMinimumTime, elapsedTime)
+	}
 }


### PR DESCRIPTION
# Enable backoff strategies

Add support for linear, exponential, and custom backoff strategies with optional backoff limit

Issue #5 

## This PR introduces the ability to configure retry backoff strategies in the following ways:

- Linear backoff: Retry delays increase linearly with each attempt.
- Exponential backoff: Retry delays increase exponentially based on the number of attempts.
- Custom backoff: Users can now provide their own custom backoff strategy.

Additionally, a new backoff limit is introduced to prevent excessively high retry delays. If the limit is set to 0, no upper limit will be applied. Otherwise, the backoff duration is capped to ensure that delays do not exceed the specified maximum.

## Changes:

Added `WithLinearBackoff()`, `WithExponentialBackoff()`, and `WithCustomBackoff()` to support different backoff strategies.
Introduced `backoffLimit` in RetryConfig  and `WithBackoffLimit` to cap the backoff time